### PR TITLE
feat: Add audit logging for authentication events (#2)

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
@@ -10,6 +10,7 @@ from app.dependencies import get_current_user
 from app.models.database import User
 from app.models.schemas import UserResponse, LoginRequest, TokenResponse
 from app.services.auth import AuthService
+from app.services.audit import AuditService
 
 router = APIRouter()
 
@@ -18,19 +19,33 @@ router = APIRouter()
 async def login(
     request: LoginRequest,
     db: Annotated[AsyncSession, Depends(get_db)],
+    http_request: Request,
 ):
     """Authenticate user with Cognito."""
     auth_service = AuthService()
+    audit = AuditService()
+
     try:
         result = await auth_service.authenticate(
             request.username, request.password
         )
 
         # Ensure user exists in database
-        await auth_service.get_or_create_user(
+        user = await auth_service.get_or_create_user(
             db,
             cognito_sub=result["sub"],
             email=request.username,
+        )
+
+        # Log successful login
+        await audit.log_action(
+            user=user,
+            action="auth:login",
+            resource_type="auth",
+            resource_ids=[request.username],
+            request=http_request,
+            status="success",
+            request_data={"username": request.username},
         )
 
         return TokenResponse(
@@ -39,6 +54,17 @@ async def login(
             refresh_token=result.get("refresh_token"),
         )
     except Exception as e:
+        # Log failed login attempt
+        await audit.log_action(
+            user=None,
+            action="auth:login",
+            resource_type="auth",
+            resource_ids=[request.username],
+            request=http_request,
+            status="failed",
+            request_data={"username": request.username},
+            response_data={"error": str(e), "error_type": type(e).__name__},
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=str(e),
@@ -46,16 +72,39 @@ async def login(
 
 
 @router.post("/refresh", response_model=TokenResponse)
-async def refresh_token(refresh_token: str):
+async def refresh_token(refresh_token: str, http_request: Request):
     """Refresh access token."""
     auth_service = AuthService()
+    audit = AuditService()
+
     try:
         result = await auth_service.refresh_token(refresh_token)
+
+        # Log successful token refresh (user unknown from refresh token)
+        await audit.log_action(
+            user=None,
+            action="auth:refresh",
+            resource_type="auth",
+            resource_ids=["token"],
+            request=http_request,
+            status="success",
+        )
+
         return TokenResponse(
             access_token=result["access_token"],
             expires_in=result["expires_in"],
         )
     except Exception as e:
+        # Log failed token refresh
+        await audit.log_action(
+            user=None,
+            action="auth:refresh",
+            resource_type="auth",
+            resource_ids=["token"],
+            request=http_request,
+            status="failed",
+            response_data={"error": str(e), "error_type": type(e).__name__},
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=str(e),
@@ -73,7 +122,20 @@ async def get_current_user_info(
 @router.post("/logout")
 async def logout(
     user: Annotated[User, Depends(get_current_user)],
+    http_request: Request,
 ):
     """Logout user (client should discard tokens)."""
+    audit = AuditService()
+
+    # Log logout event
+    await audit.log_action(
+        user=user,
+        action="auth:logout",
+        resource_type="auth",
+        resource_ids=[user.email],
+        request=http_request,
+        status="success",
+    )
+
     # Cognito tokens are stateless, logout is client-side
     return {"status": "logged_out"}

--- a/backend/app/services/audit.py
+++ b/backend/app/services/audit.py
@@ -17,7 +17,7 @@ class AuditService:
 
     async def log_action(
         self,
-        user: User,
+        user: Optional[User],
         action: str,
         resource_type: str,
         resource_ids: list[str],
@@ -36,7 +36,7 @@ class AuditService:
         async with async_session_maker() as session:
             for resource_id in resource_ids:
                 log_entry = AuditLog(
-                    user_id=user.id,
+                    user_id=user.id if user else None,
                     action=action,
                     resource_type=resource_type,
                     resource_id=resource_id,

--- a/backend/tests/integration/test_auth.py
+++ b/backend/tests/integration/test_auth.py
@@ -1,0 +1,143 @@
+"""Integration tests for auth endpoints."""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_login_success_logs_audit(client: AsyncClient):
+    """Test that successful login is logged to audit."""
+    with patch("app.api.routes.auth.AuthService") as mock_auth_class:
+        mock_auth = AsyncMock()
+        mock_auth.authenticate.return_value = {
+            "sub": "user-123",
+            "access_token": "token123",
+            "expires_in": 3600,
+            "refresh_token": "refresh123",
+        }
+        mock_auth.get_or_create_user.return_value = AsyncMock(
+            id="user-123",
+            email="test@example.com",
+        )
+        mock_auth_class.return_value = mock_auth
+
+        with patch("app.api.routes.auth.AuditService") as mock_audit_class:
+            mock_audit = AsyncMock()
+            mock_audit_class.return_value = mock_audit
+
+            response = await client.post(
+                "/api/auth/login",
+                json={"username": "test@example.com", "password": "password123"},
+            )
+
+            assert response.status_code == 200
+
+            # Verify audit log was called with success status
+            mock_audit.log_action.assert_called_once()
+            call_kwargs = mock_audit.log_action.call_args.kwargs
+            assert call_kwargs["action"] == "auth:login"
+            assert call_kwargs["status"] == "success"
+            assert call_kwargs["resource_type"] == "auth"
+
+
+@pytest.mark.asyncio
+async def test_login_failure_logs_audit(client: AsyncClient):
+    """Test that failed login attempts are logged to audit."""
+    with patch("app.api.routes.auth.AuthService") as mock_auth_class:
+        mock_auth = AsyncMock()
+        mock_auth.authenticate.side_effect = Exception("Invalid credentials")
+        mock_auth_class.return_value = mock_auth
+
+        with patch("app.api.routes.auth.AuditService") as mock_audit_class:
+            mock_audit = AsyncMock()
+            mock_audit_class.return_value = mock_audit
+
+            response = await client.post(
+                "/api/auth/login",
+                json={"username": "bad@example.com", "password": "wrongpassword"},
+            )
+
+            assert response.status_code == 401
+
+            # Verify audit log was called with failed status
+            mock_audit.log_action.assert_called_once()
+            call_kwargs = mock_audit.log_action.call_args.kwargs
+            assert call_kwargs["action"] == "auth:login"
+            assert call_kwargs["status"] == "failed"
+            assert call_kwargs["user"] is None  # No user for failed login
+            assert "error" in call_kwargs["response_data"]
+
+
+@pytest.mark.asyncio
+async def test_logout_logs_audit(client: AsyncClient):
+    """Test that logout is logged to audit."""
+    with patch("app.api.routes.auth.AuditService") as mock_audit_class:
+        mock_audit = AsyncMock()
+        mock_audit_class.return_value = mock_audit
+
+        response = await client.post("/api/auth/logout")
+
+        assert response.status_code == 200
+
+        # Verify audit log was called
+        mock_audit.log_action.assert_called_once()
+        call_kwargs = mock_audit.log_action.call_args.kwargs
+        assert call_kwargs["action"] == "auth:logout"
+        assert call_kwargs["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_success_logs_audit(client: AsyncClient):
+    """Test that successful token refresh is logged to audit."""
+    with patch("app.api.routes.auth.AuthService") as mock_auth_class:
+        mock_auth = AsyncMock()
+        mock_auth.refresh_token.return_value = {
+            "access_token": "newtoken123",
+            "expires_in": 3600,
+        }
+        mock_auth_class.return_value = mock_auth
+
+        with patch("app.api.routes.auth.AuditService") as mock_audit_class:
+            mock_audit = AsyncMock()
+            mock_audit_class.return_value = mock_audit
+
+            response = await client.post(
+                "/api/auth/refresh",
+                params={"refresh_token": "valid_refresh_token"},
+            )
+
+            assert response.status_code == 200
+
+            # Verify audit log was called
+            mock_audit.log_action.assert_called_once()
+            call_kwargs = mock_audit.log_action.call_args.kwargs
+            assert call_kwargs["action"] == "auth:refresh"
+            assert call_kwargs["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_failure_logs_audit(client: AsyncClient):
+    """Test that failed token refresh is logged to audit."""
+    with patch("app.api.routes.auth.AuthService") as mock_auth_class:
+        mock_auth = AsyncMock()
+        mock_auth.refresh_token.side_effect = Exception("Token expired")
+        mock_auth_class.return_value = mock_auth
+
+        with patch("app.api.routes.auth.AuditService") as mock_audit_class:
+            mock_audit = AsyncMock()
+            mock_audit_class.return_value = mock_audit
+
+            response = await client.post(
+                "/api/auth/refresh",
+                params={"refresh_token": "invalid_token"},
+            )
+
+            assert response.status_code == 401
+
+            # Verify audit log was called with failed status
+            mock_audit.log_action.assert_called_once()
+            call_kwargs = mock_audit.log_action.call_args.kwargs
+            assert call_kwargs["action"] == "auth:refresh"
+            assert call_kwargs["status"] == "failed"
+            assert "error" in call_kwargs["response_data"]


### PR DESCRIPTION
## Summary
Fixes #2

Add audit logging for login, logout, and token refresh events for security compliance.

## Changes
- Update `AuditService.log_action` to accept `Optional[User]` for unauthenticated requests
- Add audit logging to login endpoint (success and failure)
- Add audit logging to logout endpoint
- Add audit logging to token refresh endpoint (success and failure)
- Add integration tests for all auth audit scenarios

## Auth Events Logged

| Event | Status | User |
|-------|--------|------|
| `auth:login` | success | User from DB |
| `auth:login` | failed | None (unauthenticated) |
| `auth:logout` | success | Current user |
| `auth:refresh` | success | None (token-based) |
| `auth:refresh` | failed | None (token-based) |

## Test Plan
- [x] Integration tests added for all auth audit scenarios
- [x] Verified syntax correctness
- [ ] CI tests pass

Generated with Claude Code