### PR TITLE
feat: Add audit logging for AWS account management (#3)

### DIFF
--- a/backend/app/api/routes/accounts.py
+++ b/backend/app/api/routes/accounts.py
@@ -3,7 +3,7 @@
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -11,6 +11,7 @@ from app.database import get_db
 from app.dependencies import RequireAdmin
 from app.models.database import AWSAccount
 from app.models.schemas import AWSAccountCreate, AWSAccountResponse
+from app.services.audit import AuditService
 
 router = APIRouter()
 
@@ -31,8 +32,11 @@ async def create_account(
     account: AWSAccountCreate,
     user: RequireAdmin,
     db: Annotated[AsyncSession, Depends(get_db)],
+    http_request: Request,
 ):
     """Add a new AWS account (admin only)."""
+    audit = AuditService()
+
     # Check if account already exists
     existing = await db.execute(
         select(AWSAccount).where(AWSAccount.account_id == account.account_id)
@@ -47,6 +51,21 @@ async def create_account(
     db.add(db_account)
     await db.commit()
     await db.refresh(db_account)
+
+    # Log account creation
+    await audit.log_action(
+        user=user,
+        action="account:create",
+        resource_type="aws_account",
+        resource_ids=[account.account_id],
+        request=http_request,
+        status="success",
+        request_data={
+            "account_id": account.account_id,
+            "account_name": account.account_name,
+            "role_arn": account.role_arn,
+        },
+    )
 
     return db_account
 
@@ -77,8 +96,11 @@ async def update_account(
     account_update: AWSAccountCreate,
     user: RequireAdmin,
     db: Annotated[AsyncSession, Depends(get_db)],
+    http_request: Request,
 ):
     """Update AWS account (admin only)."""
+    audit = AuditService()
+
     query = select(AWSAccount).where(AWSAccount.id == account_id)
     result = await db.execute(query)
     account = result.scalar_one_or_none()
@@ -89,11 +111,36 @@ async def update_account(
             detail="Account not found",
         )
 
+    # Capture before values for audit
+    before_values = {
+        "account_id": account.account_id,
+        "account_name": account.account_name,
+        "role_arn": account.role_arn,
+    }
+
     for key, value in account_update.model_dump().items():
         setattr(account, key, value)
 
     await db.commit()
     await db.refresh(account)
+
+    # Capture after values for audit
+    after_values = {
+        "account_id": account.account_id,
+        "account_name": account.account_name,
+        "role_arn": account.role_arn,
+    }
+
+    # Log account update with before/after values
+    await audit.log_action(
+        user=user,
+        action="account:update",
+        resource_type="aws_account",
+        resource_ids=[account.account_id],
+        request=http_request,
+        status="success",
+        request_data={"before": before_values, "after": after_values},
+    )
 
     return account
 
@@ -103,8 +150,11 @@ async def delete_account(
     account_id: UUID,
     user: RequireAdmin,
     db: Annotated[AsyncSession, Depends(get_db)],
+    http_request: Request,
 ):
     """Delete AWS account (admin only)."""
+    audit = AuditService()
+
     query = select(AWSAccount).where(AWSAccount.id == account_id)
     result = await db.execute(query)
     account = result.scalar_one_or_none()
@@ -115,8 +165,26 @@ async def delete_account(
             detail="Account not found",
         )
 
+    # Capture account details before deletion for audit
+    deleted_account_data = {
+        "account_id": account.account_id,
+        "account_name": account.account_name,
+        "role_arn": account.role_arn,
+    }
+
     await db.delete(account)
     await db.commit()
+
+    # Log account deletion
+    await audit.log_action(
+        user=user,
+        action="account:delete",
+        resource_type="aws_account",
+        resource_ids=[deleted_account_data["account_id"]],
+        request=http_request,
+        status="success",
+        request_data=deleted_account_data,
+    )
 
 
 @router.post("/{account_id}/verify")
@@ -124,8 +192,11 @@ async def verify_account(
     account_id: UUID,
     user: RequireAdmin,
     db: Annotated[AsyncSession, Depends(get_db)],
+    http_request: Request,
 ):
     """Verify AWS account access by testing AssumeRole (admin only)."""
+    audit = AuditService()
+
     query = select(AWSAccount).where(AWSAccount.id == account_id)
     result = await db.execute(query)
     account = result.scalar_one_or_none()
@@ -145,8 +216,38 @@ async def verify_account(
             role_arn=account.role_arn,
             external_id=account.external_id,
         )
+
+        # Log successful verification
+        await audit.log_action(
+            user=user,
+            action="account:verify",
+            resource_type="aws_account",
+            resource_ids=[account.account_id],
+            request=http_request,
+            status="success",
+            request_data={
+                "account_id": account.account_id,
+                "role_arn": account.role_arn,
+            },
+        )
+
         return {"status": "verified", "message": "Successfully assumed role"}
     except Exception as e:
+        # Log failed verification
+        await audit.log_action(
+            user=user,
+            action="account:verify",
+            resource_type="aws_account",
+            resource_ids=[account.account_id],
+            request=http_request,
+            status="failed",
+            request_data={
+                "account_id": account.account_id,
+                "role_arn": account.role_arn,
+            },
+            response_data={"error": str(e), "error_type": type(e).__name__},
+        )
+
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Failed to assume role: {str(e)}",

--- a/backend/app/services/audit.py
+++ b/backend/app/services/audit.py
@@ -17,7 +17,7 @@ class AuditService:
 
     async def log_action(
         self,
-        user: User,
+        user: Optional[User],
         action: str,
         resource_type: str,
         resource_ids: list[str],
@@ -36,7 +36,7 @@ class AuditService:
         async with async_session_maker() as session:
             for resource_id in resource_ids:
                 log_entry = AuditLog(
-                    user_id=user.id,
+                    user_id=user.id if user else None,
                     action=action,
                     resource_type=resource_type,
                     resource_id=resource_id,

--- a/backend/tests/integration/test_accounts.py
+++ b/backend/tests/integration/test_accounts.py
@@ -1,0 +1,195 @@
+"""Integration tests for account management endpoints."""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_create_account_logs_audit(client: AsyncClient, db_session):
+    """Test that account creation is logged to audit."""
+    with patch("app.api.routes.accounts.AuditService") as mock_audit_class:
+        mock_audit = AsyncMock()
+        mock_audit_class.return_value = mock_audit
+
+        response = await client.post(
+            "/api/accounts",
+            json={
+                "account_id": "123456789012",
+                "account_name": "Test Account",
+                "role_arn": "arn:aws:iam::123456789012:role/TestRole",
+            },
+        )
+
+        assert response.status_code == 201
+
+        # Verify audit log was called
+        mock_audit.log_action.assert_called_once()
+        call_kwargs = mock_audit.log_action.call_args.kwargs
+        assert call_kwargs["action"] == "account:create"
+        assert call_kwargs["status"] == "success"
+        assert call_kwargs["resource_type"] == "aws_account"
+        assert "account_id" in call_kwargs["request_data"]
+        assert "role_arn" in call_kwargs["request_data"]
+
+
+@pytest.mark.asyncio
+async def test_update_account_logs_before_after_values(client: AsyncClient, db_session):
+    """Test that account update logs before/after values."""
+    # First create an account
+    with patch("app.api.routes.accounts.AuditService") as mock_audit_class:
+        mock_audit = AsyncMock()
+        mock_audit_class.return_value = mock_audit
+
+        create_response = await client.post(
+            "/api/accounts",
+            json={
+                "account_id": "123456789013",
+                "account_name": "Original Name",
+                "role_arn": "arn:aws:iam::123456789013:role/OriginalRole",
+            },
+        )
+        assert create_response.status_code == 201
+        account_uuid = create_response.json()["id"]
+
+    # Now update it
+    with patch("app.api.routes.accounts.AuditService") as mock_audit_class:
+        mock_audit = AsyncMock()
+        mock_audit_class.return_value = mock_audit
+
+        update_response = await client.put(
+            f"/api/accounts/{account_uuid}",
+            json={
+                "account_id": "123456789013",
+                "account_name": "Updated Name",
+                "role_arn": "arn:aws:iam::123456789013:role/UpdatedRole",
+            },
+        )
+
+        assert update_response.status_code == 200
+
+        # Verify audit log was called with before/after values
+        mock_audit.log_action.assert_called_once()
+        call_kwargs = mock_audit.log_action.call_args.kwargs
+        assert call_kwargs["action"] == "account:update"
+        assert call_kwargs["status"] == "success"
+        assert "before" in call_kwargs["request_data"]
+        assert "after" in call_kwargs["request_data"]
+        assert call_kwargs["request_data"]["before"]["account_name"] == "Original Name"
+        assert call_kwargs["request_data"]["after"]["account_name"] == "Updated Name"
+
+
+@pytest.mark.asyncio
+async def test_delete_account_logs_audit(client: AsyncClient, db_session):
+    """Test that account deletion is logged to audit."""
+    # First create an account
+    with patch("app.api.routes.accounts.AuditService") as mock_audit_class:
+        mock_audit = AsyncMock()
+        mock_audit_class.return_value = mock_audit
+
+        create_response = await client.post(
+            "/api/accounts",
+            json={
+                "account_id": "123456789014",
+                "account_name": "To Be Deleted",
+                "role_arn": "arn:aws:iam::123456789014:role/DeleteMe",
+            },
+        )
+        assert create_response.status_code == 201
+        account_uuid = create_response.json()["id"]
+
+    # Now delete it
+    with patch("app.api.routes.accounts.AuditService") as mock_audit_class:
+        mock_audit = AsyncMock()
+        mock_audit_class.return_value = mock_audit
+
+        delete_response = await client.delete(f"/api/accounts/{account_uuid}")
+
+        assert delete_response.status_code == 204
+
+        # Verify audit log was called
+        mock_audit.log_action.assert_called_once()
+        call_kwargs = mock_audit.log_action.call_args.kwargs
+        assert call_kwargs["action"] == "account:delete"
+        assert call_kwargs["status"] == "success"
+        assert call_kwargs["request_data"]["account_id"] == "123456789014"
+
+
+@pytest.mark.asyncio
+async def test_verify_account_success_logs_audit(client: AsyncClient, db_session):
+    """Test that successful account verification is logged to audit."""
+    # First create an account
+    with patch("app.api.routes.accounts.AuditService") as mock_audit_class:
+        mock_audit = AsyncMock()
+        mock_audit_class.return_value = mock_audit
+
+        create_response = await client.post(
+            "/api/accounts",
+            json={
+                "account_id": "123456789015",
+                "account_name": "Verify Me",
+                "role_arn": "arn:aws:iam::123456789015:role/VerifyRole",
+            },
+        )
+        assert create_response.status_code == 201
+        account_uuid = create_response.json()["id"]
+
+    # Now verify it
+    with patch("app.api.routes.accounts.AuditService") as mock_audit_class:
+        mock_audit = AsyncMock()
+        mock_audit_class.return_value = mock_audit
+
+        with patch("app.services.aws.base.AWSBaseService") as mock_aws_class:
+            mock_aws = AsyncMock()
+            mock_aws_class.return_value = mock_aws
+
+            verify_response = await client.post(f"/api/accounts/{account_uuid}/verify")
+
+            assert verify_response.status_code == 200
+
+            # Verify audit log was called
+            mock_audit.log_action.assert_called_once()
+            call_kwargs = mock_audit.log_action.call_args.kwargs
+            assert call_kwargs["action"] == "account:verify"
+            assert call_kwargs["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_verify_account_failure_logs_audit(client: AsyncClient, db_session):
+    """Test that failed account verification is logged to audit."""
+    # First create an account
+    with patch("app.api.routes.accounts.AuditService") as mock_audit_class:
+        mock_audit = AsyncMock()
+        mock_audit_class.return_value = mock_audit
+
+        create_response = await client.post(
+            "/api/accounts",
+            json={
+                "account_id": "123456789016",
+                "account_name": "Fail Verify",
+                "role_arn": "arn:aws:iam::123456789016:role/BadRole",
+            },
+        )
+        assert create_response.status_code == 201
+        account_uuid = create_response.json()["id"]
+
+    # Now try to verify it (will fail)
+    with patch("app.api.routes.accounts.AuditService") as mock_audit_class:
+        mock_audit = AsyncMock()
+        mock_audit_class.return_value = mock_audit
+
+        with patch("app.services.aws.base.AWSBaseService") as mock_aws_class:
+            mock_aws = AsyncMock()
+            mock_aws.verify_role_access.side_effect = Exception("Access denied")
+            mock_aws_class.return_value = mock_aws
+
+            verify_response = await client.post(f"/api/accounts/{account_uuid}/verify")
+
+            assert verify_response.status_code == 400
+
+            # Verify audit log was called with failed status
+            mock_audit.log_action.assert_called_once()
+            call_kwargs = mock_audit.log_action.call_args.kwargs
+            assert call_kwargs["action"] == "account:verify"
+            assert call_kwargs["status"] == "failed"
+            assert "error" in call_kwargs["response_data"]


### PR DESCRIPTION
## Summary
Fixes #3

Add audit logging for AWS account create, update, delete, and verify operations for compliance tracking.

## Changes
- Add audit logging to `POST /api/accounts` (create)
- Add audit logging to `PUT /api/accounts/{id}` (update with before/after values)
- Add audit logging to `DELETE /api/accounts/{id}` (delete)
- Add audit logging to `POST /api/accounts/{id}/verify` (success/failure)
- Update `AuditService.log_action` to accept `Optional[User]`
- Add integration tests for all scenarios

## Account Events Logged

| Action | Status | Request Data |
|--------|--------|--------------|
| `account:create` | success | account_id, account_name, role_arn |
| `account:update` | success | before/after values |
| `account:delete` | success | deleted account details |
| `account:verify` | success/failed | account_id, role_arn, error (if failed) |

## Test Plan
- [x] Integration tests added for all account audit scenarios
- [x] Verified syntax correctness
- [ ] CI tests pass

Generated with Claude Code