### PR TITLE
feat: Implement audit log export for compliance reporting (#7)

### DIFF
--- a/backend/app/api/routes/audit.py
+++ b/backend/app/api/routes/audit.py
@@ -1,9 +1,13 @@
 """Audit log endpoints."""
 
+import csv
+import io
+import json
 from datetime import datetime
-from typing import Annotated, Optional
+from typing import Annotated, Literal, Optional
 
 from fastapi import APIRouter, Depends, Query
+from fastapi.responses import StreamingResponse
 from sqlalchemy import select, func, desc
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -13,6 +17,8 @@ from app.models.database import AuditLog, User
 from app.models.schemas import AuditLogResponse, AuditLogListResponse
 
 router = APIRouter()
+
+MAX_EXPORT_RECORDS = 10000
 
 
 @router.get("", response_model=AuditLogListResponse)
@@ -69,6 +75,7 @@ async def list_audit_logs(
             region=log.region,
             status=log.status,
             request_data=log.request_data,
+            response_data=log.response_data,
             created_at=log.created_at,
         )
         items.append(log_response)
@@ -80,6 +87,100 @@ async def list_audit_logs(
         page_size=page_size,
         has_more=(page * page_size) < total,
     )
+
+
+@router.get("/export")
+async def export_audit_logs(
+    user: RequireAdmin,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    format: Literal["csv", "json"] = Query("csv", description="Export format"),
+    action: Optional[str] = Query(None, description="Filter by action type"),
+    resource_type: Optional[str] = Query(None, description="Filter by resource type"),
+    user_email: Optional[str] = Query(None, description="Filter by user email"),
+    start_date: Optional[datetime] = Query(None, description="Filter from date"),
+    end_date: Optional[datetime] = Query(None, description="Filter to date"),
+    status: Optional[str] = Query(None, description="Filter by status"),
+):
+    """Export audit logs as CSV or JSON (admin only). Max 10,000 records."""
+    # Build query with same filters as list endpoint
+    query = select(AuditLog).join(User, AuditLog.user_id == User.id, isouter=True)
+
+    if action:
+        query = query.where(AuditLog.action.ilike(f"%{action}%"))
+    if resource_type:
+        query = query.where(AuditLog.resource_type == resource_type)
+    if user_email:
+        query = query.where(User.email.ilike(f"%{user_email}%"))
+    if start_date:
+        query = query.where(AuditLog.created_at >= start_date)
+    if end_date:
+        query = query.where(AuditLog.created_at <= end_date)
+    if status:
+        query = query.where(AuditLog.status == status)
+
+    # Order and limit
+    query = query.order_by(desc(AuditLog.created_at)).limit(MAX_EXPORT_RECORDS)
+
+    result = await db.execute(query)
+    logs = result.scalars().all()
+
+    if format == "json":
+        # Export as JSON
+        export_data = []
+        for log in logs:
+            export_data.append({
+                "id": str(log.id),
+                "user_email": log.user.email if log.user else None,
+                "action": log.action,
+                "resource_type": log.resource_type,
+                "resource_id": log.resource_id,
+                "aws_account_id": log.aws_account_id,
+                "region": log.region,
+                "status": log.status,
+                "request_data": log.request_data,
+                "response_data": log.response_data,
+                "created_at": log.created_at.isoformat(),
+            })
+
+        json_content = json.dumps(export_data, indent=2)
+        return StreamingResponse(
+            io.StringIO(json_content),
+            media_type="application/json",
+            headers={"Content-Disposition": "attachment; filename=audit_logs.json"},
+        )
+    else:
+        # Export as CSV
+        output = io.StringIO()
+        writer = csv.writer(output)
+
+        # Header row
+        writer.writerow([
+            "id", "user_email", "action", "resource_type", "resource_id",
+            "aws_account_id", "region", "status", "request_data", "response_data", "created_at"
+        ])
+
+        # Data rows
+        for log in logs:
+            writer.writerow([
+                str(log.id),
+                log.user.email if log.user else "",
+                log.action,
+                log.resource_type,
+                log.resource_id,
+                log.aws_account_id or "",
+                log.region or "",
+                log.status,
+                json.dumps(log.request_data) if log.request_data else "",
+                json.dumps(log.response_data) if log.response_data else "",
+                log.created_at.isoformat(),
+            ])
+
+        output.seek(0)
+        return StreamingResponse(
+            output,
+            media_type="text/csv",
+            headers={"Content-Disposition": "attachment; filename=audit_logs.csv"},
+        )
 
 
 @router.get("/{log_id}", response_model=AuditLogResponse)
@@ -107,5 +208,6 @@ async def get_audit_log(
         region=log.region,
         status=log.status,
         request_data=log.request_data,
+        response_data=log.response_data,
         created_at=log.created_at,
     )

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -183,6 +183,7 @@ class AuditLogResponse(BaseModel):
     region: Optional[str] = None
     status: str
     request_data: Optional[dict] = None
+    response_data: Optional[dict] = None
     created_at: datetime
 
     class Config:

--- a/frontend/src/pages/Audit.tsx
+++ b/frontend/src/pages/Audit.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { FileText, ChevronLeft, ChevronRight, Search, Filter } from 'lucide-react';
+import { FileText, ChevronLeft, ChevronRight, Search, Download } from 'lucide-react';
 import { auditApi, type AuditFilters } from '@/services/audit';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
 import { format } from 'date-fns';
@@ -16,19 +16,49 @@ export default function Audit() {
   const [filters, setFilters] = useState<AuditFilters>({});
   const [page, setPage] = useState(1);
   const [expandedLog, setExpandedLog] = useState<string | null>(null);
+  const [isExporting, setIsExporting] = useState(false);
 
   const { data, isLoading } = useQuery({
     queryKey: ['audit', filters, page],
     queryFn: () => auditApi.list(filters, page, 50),
   });
 
+  const handleExport = async (format: 'csv' | 'json') => {
+    setIsExporting(true);
+    try {
+      await auditApi.export(filters, format);
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
   return (
     <div className="space-y-6 mt-16">
-      <div>
-        <h1 className="text-2xl font-bold text-gray-900">Audit Log</h1>
-        <p className="text-gray-600">
-          Track all actions performed on AWS resources
-        </p>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Audit Log</h1>
+          <p className="text-gray-600">
+            Track all actions performed on AWS resources
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={() => handleExport('csv')}
+            disabled={isExporting}
+            className="btn-secondary flex items-center gap-2"
+          >
+            <Download className="h-4 w-4" />
+            {isExporting ? 'Exporting...' : 'Export CSV'}
+          </button>
+          <button
+            onClick={() => handleExport('json')}
+            disabled={isExporting}
+            className="btn-secondary flex items-center gap-2"
+          >
+            <Download className="h-4 w-4" />
+            {isExporting ? 'Exporting...' : 'Export JSON'}
+          </button>
+        </div>
       </div>
 
       {/* Filters */}

--- a/frontend/src/services/audit.ts
+++ b/frontend/src/services/audit.ts
@@ -30,4 +30,36 @@ export const auditApi = {
     const response = await api.get<AuditLogListResponse>(`/audit?${params}`);
     return response.data;
   },
+
+  export: async (
+    filters: AuditFilters = {},
+    format: 'csv' | 'json' = 'csv'
+  ): Promise<void> => {
+    const params = new URLSearchParams();
+
+    if (filters.action) params.append('action', filters.action);
+    if (filters.resource_type) params.append('resource_type', filters.resource_type);
+    if (filters.user_email) params.append('user_email', filters.user_email);
+    if (filters.start_date) params.append('start_date', filters.start_date);
+    if (filters.end_date) params.append('end_date', filters.end_date);
+    if (filters.status) params.append('status', filters.status);
+    params.append('format', format);
+
+    const response = await api.get(`/audit/export?${params}`, {
+      responseType: 'blob',
+    });
+
+    // Create download link
+    const blob = new Blob([response.data], {
+      type: format === 'csv' ? 'text/csv' : 'application/json',
+    });
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `audit_logs.${format}`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    window.URL.revokeObjectURL(url);
+  },
 };


### PR DESCRIPTION
## Summary
Fixes #7

Implements audit log export functionality for compliance documentation and reporting.

## Changes

### Backend
- Added `/api/audit/export` endpoint supporting CSV and JSON formats
- Added `response_data` field to `AuditLogResponse` schema
- Export respects all filter parameters (action, resource_type, user_email, date range, status)
- Limited to 10,000 records per export for performance

### Frontend
- Added Export CSV and Export JSON buttons to the Audit page header
- Shows loading state during export
- Triggers browser download with appropriate file type

## Test Plan
- [ ] Verify CSV export downloads correctly with all columns
- [ ] Verify JSON export downloads correctly with proper formatting
- [ ] Verify filters are respected in exports
- [ ] Verify export works with no filters (exports all records up to limit)
- [ ] Verify large exports complete without timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)